### PR TITLE
feat: Generate inline enum values as union type

### DIFF
--- a/src/generators/APITypingsGenerator.ts
+++ b/src/generators/APITypingsGenerator.ts
@@ -239,6 +239,7 @@ export class APITypingsGenerator {
         imports: newImports,
         value,
         codeBlocks: newCodeBlocks,
+        description,
       } = property.getTypeString(this.objects);
 
       imports = { ...imports, ...newImports };
@@ -246,7 +247,7 @@ export class APITypingsGenerator {
 
       codeBlock.addProperty({
         name: property.name,
-        description: property.description,
+        description: [property.description, description].join(newLineChar),
         value,
         isRequired: isPatternProperty(property.name) || requiredProperties[property.name],
       });

--- a/src/generators/BaseCodeBlock.ts
+++ b/src/generators/BaseCodeBlock.ts
@@ -12,4 +12,5 @@ export interface GeneratorResultInterface {
   codeBlocks: CodeBlocksArray;
   imports: Dictionary<boolean>;
   value: string;
+  description?: string;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -54,3 +54,22 @@ export function trimStringDoubleSpaces(string: string): string {
 export function quoteJavaScriptValue(value: string | number) {
   return isString(value) ? `'${value}'` : value;
 }
+
+/**
+ * Removes empty string array elements from start and end of array and returns the new array
+ *
+ * @example trimArray(['', 'First', '', 'Second', '', '']) => ['First', '', 'Second']
+ */
+export function trimArray(array: string[]): string[] {
+  let trimmedArray = array.map((v) => v.trim());
+
+  while (trimmedArray[0] === '') {
+    trimmedArray.shift();
+  }
+
+  while (trimmedArray[trimmedArray.length - 1] === '') {
+    trimmedArray.pop();
+  }
+
+  return trimmedArray;
+}


### PR DESCRIPTION
### Breaking change

Before now the generator created TypeScript `enum` types for properties with inline-descriptive enum values. Now it will be generated as union type with the constant, which can be imported to project.

JSON Schema:

```json
{
  "users_online_info": {
    "type": "object",
    "properties": {
      "status": {
        "type": "string",
        "description": "In case user online is not visible, it indicates approximate timeframe of user online",
        "enum": [
          "recently",
          "last_week",
          "last_month",
          "long_ago",
          "not_show"
        ]
      }
    },
    "required": [
      "visible"
    ]
  }
}
```

Before:
```ts

// users_online_info status enum
export enum UsersOnlineInfoStatusEnum {
  RECENTLY = 'recently',
  LAST_WEEK = 'last_week',
  LAST_MONTH = 'last_month',
  LONG_AGO = 'long_ago',
  NOT_SHOW = 'not_show',
}

// users_online_info
export interface UsersOnlineInfo {
  /**
   * In case user online is not visible, it indicates approximate timeframe of user online
   */
  status?: UsersOnlineInfoStatusEnum;
}
```

After:

```ts
// users_online_info status enumNames
export const UsersOnlineInfoStatusEnumNames = {
  RECENTLY: 'recently',
  LAST_WEEK: 'last_week',
  LAST_MONTH: 'last_month',
  LONG_AGO: 'long_ago',
  NOT_SHOW: 'not_show',
} as const;

// users_online_info
export interface UsersOnlineInfo {
  /**
   * In case user online is not visible, it indicates approximate timeframe of user online
   */
  status?: 'recently' | 'last_week' | 'last_month' | 'long_ago' | 'not_show';
}
```