### PR TITLE
fix(ci): add publishConfig with access to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
     "name": "VK",
     "url": "https://vk.com"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "VK",
     "VK API",


### PR DESCRIPTION
- relates to #261

Воркфлоу `publish.yml` упал при `yarn publish`, т.к. в `package.json` не хватало `"publishConfig": { "access": "public" }"`.

## На счёт завершения публикации версии `v0.17.0`

Т.к. воркфлоу `publish.yml` не учитывает, что шаг `Publushing release` может упасть, версия и тег на версию `v0.17.0` уже запушилась в `master`. Если заново запустить воркфлоу с параметром `0.17.0`, то он упадёт на шаг `yarn version --new-version ${{ github.event.inputs.version }} --no-commit-hooks` с ошибкой что версия уже есть.

Чтобы не откатывать коммит, опубликовал версию локально https://www.npmjs.com/package/@vkontakte/api-schema-typescript-generator/v/0.17.0.